### PR TITLE
Fixed dutch locale tussenvoegsel reference

### DIFF
--- a/locales/nl.go
+++ b/locales/nl.go
@@ -5,7 +5,7 @@ var Nl = map[string]interface{}{
 		"first_name": []string{
 			"Amber", "Anna", "Anne", "Anouk", "Bas", "Bram", "Britt", "Daan", "Emma", "Eva", "Femke", "Finn", "Fleur", "Iris", "Isa", "Jan", "Jasper", "Jayden", "Jesse", "Johannes", "Julia", "Julian", "Kevin", "Lars", "Lieke", "Lisa", "Lotte", "Lucas", "Luuk", "Maud", "Max", "Mike", "Milan", "Nick", "Niels", "Noa", "Rick", "Roos", "Ruben", "Sander", "Sanne", "Sem", "Sophie", "Stijn", "Sven", "Thijs", "Thijs", "Thomas", "Tim", "Tom",
 		},
-		"tussenvoegsel": []string{
+		"middle_name": []string{
 			"van", "van de", "van den", "van 't", "van het", "de", "den",
 		},
 		"last_name": []string{
@@ -18,7 +18,7 @@ var Nl = map[string]interface{}{
 			"Jr.", "Sr.", "I", "II", "III", "IV", "V",
 		},
 		"name": []string{
-			"#{name.prefix} #{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name} #{name.suffix}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.tussenvoegsel} #{name.last_name}", "#{name.first_name} #{name.tussenvoegsel} #{name.last_name}",
+			"#{name.prefix} #{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name} #{name.suffix}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.middle_name} #{name.last_name}", "#{name.first_name} #{name.middle_name} #{name.last_name}",
 		},
 	},
 	"phone_number": map[string]interface{}{

--- a/locales/nl.go
+++ b/locales/nl.go
@@ -18,7 +18,7 @@ var Nl = map[string]interface{}{
 			"Jr.", "Sr.", "I", "II", "III", "IV", "V",
 		},
 		"name": []string{
-			"#{name.prefix} #{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name} #{name.suffix}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{tussenvoegsel} #{name.last_name}", "#{name.first_name} #{tussenvoegsel} #{name.last_name}",
+			"#{name.prefix} #{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name} #{name.suffix}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.last_name}", "#{name.first_name} #{name.tussenvoegsel} #{name.last_name}", "#{name.first_name} #{name.tussenvoegsel} #{name.last_name}",
 		},
 	},
 	"phone_number": map[string]interface{}{

--- a/yaml/nl.yml
+++ b/yaml/nl.yml
@@ -61,7 +61,7 @@ nl:
 
     name:
       first_name: ["Amber", "Anna", "Anne", "Anouk", "Bas", "Bram", "Britt", "Daan", "Emma", "Eva", "Femke", "Finn", "Fleur", "Iris", "Isa", "Jan", "Jasper", "Jayden", "Jesse", "Johannes", "Julia", "Julian", "Kevin", "Lars", "Lieke", "Lisa", "Lotte", "Lucas", "Luuk", "Maud", "Max", "Mike", "Milan", "Nick", "Niels", "Noa", "Rick", "Roos", "Ruben", "Sander", "Sanne", "Sem", "Sophie", "Stijn", "Sven", "Thijs", "Thijs", "Thomas", "Tim", "Tom"]
-      tussenvoegsel: ["van", "van de", "van den", "van 't", "van het", "de", "den"]
+      middle_name: ["van", "van de", "van den", "van 't", "van het", "de", "den"]
       last_name:  ["Bakker", "Beek", "Berg", "Boer", "Bos", "Bosch", "Brink", "Broek", "Brouwer", "Bruin", "Dam", "Dekker", "Dijk", "Dijkstra", "Graaf", "Groot", "Haan", "Hendriks", "Heuvel", "Hoek", "Jacobs", "Jansen", "Janssen", "Jong", "Klein", "Kok", "Koning", "Koster", "Leeuwen", "Linden", "Maas", "Meer", "Meijer", "Mulder", "Peters", "Ruiter", "Schouten", "Smit", "Smits", "Stichting", "Veen", "Ven", "Vermeulen", "Visser", "Vliet", "Vos", "Vries", "Wal", "Willems", "Wit"]
       prefix: [Dhr., Mevr. Dr., Bsc, Msc, Prof.]
       suffix: [Jr., Sr., I, II, III, IV, V]
@@ -70,8 +70,8 @@ nl:
         - "#{first_name} #{last_name} #{suffix}"
         - "#{first_name} #{last_name}"
         - "#{first_name} #{last_name}"
-        - "#{first_name} #{tussenvoegsel} #{last_name}"
-        - "#{first_name} #{tussenvoegsel} #{last_name}"
+        - "#{first_name} #{middle_name} #{last_name}"
+        - "#{first_name} #{middle_name} #{last_name}"
 
     phone_number:
       formats: ["(####) ######", "##########", "06########", "06 #### ####"]


### PR DESCRIPTION
Current output is for example "Sander #{tussenvoegsel} Linden". 

With this PR, this is fixed and it will be for example "Sander van den Linden".